### PR TITLE
bulk: 2026-07-26

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782772816,
-        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784403754,
-        "narHash": "sha256-d5IJVlRpIXsLaNrOyaatrlebyWzoZeSeL0m8rffyJaM=",
+        "lastModified": 1784905371,
+        "narHash": "sha256-hRABRkQfByVWBsVYu/JT1tgeNhXr6iKti87rbxBsfl0=",
         "owner": "AvengeMedia",
         "repo": "dankcalendar",
-        "rev": "86298ca65920865c0167f639da8bd010bd545a7a",
+        "rev": "c236da67fcd5c762c93d5c65a2bcc388005abf40",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784341230,
-        "narHash": "sha256-2QxkI52zrEdPPAlE5R71lqBeZxXuHwGAYl3ILCFtTjo=",
+        "lastModified": 1784857968,
+        "narHash": "sha256-83haLQzxrk6sCX76iQlloHWQ+TD0RKsK+LdVTMikNwk=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "1463198cb6d23211ee45cc6fe21acc75aa4e77b8",
+        "rev": "78d478f34ad6790faea447c37d16bab63e1d3570",
         "type": "github"
       },
       "original": {
@@ -434,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784405246,
-        "narHash": "sha256-ygru62KLDLZ4v33ae87XEW2VS8Rvh9+yXGDyJ5Y9bLI=",
+        "lastModified": 1784986205,
+        "narHash": "sha256-2JnCiA4JxySAyH++JduEQ56TJgN5l/7T0NMiA1HxUm0=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "f9e275095fa7c14a858d395556cdfb6b396c201b",
+        "rev": "be7d518035073dcac5a2812e24b1960c9fbc7a8e",
         "type": "github"
       },
       "original": {
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784293699,
-        "narHash": "sha256-NU0hTN14YgxSrTDU0ELAF7i5gjsqHxI9AsbS38nAO/4=",
+        "lastModified": 1784974217,
+        "narHash": "sha256-vYMTOExlquQSKCV5K/VjROLlfJ2D7IyAzvlvv2KAntk=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "9537416185661acf10c59cec4886105f60bf2a7e",
+        "rev": "4c03cc7e3088420b8b84d8d0937036abe13bf7a7",
         "type": "github"
       },
       "original": {
@@ -502,11 +502,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784380193,
-        "narHash": "sha256-XnpNipcSNWg+l9aHV/Ha3W1ot/r5FC7OT3//zZ9Vjbs=",
+        "lastModified": 1784874881,
+        "narHash": "sha256-u4jhSIf/Un0qZB+Cn3hTTaHSI20XeAxYbA5o4faqdJs=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "26e0cddf2447ab5ec0824b1c9a076aa1480fc57a",
+        "rev": "ef7a2a3d719af46b906c22a3ebfb7d65627b2cd2",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784343184,
-        "narHash": "sha256-xD2Fxgh6jD0m3v3ijO9+59EFlYIwIlnw8Z/yQpsAukA=",
+        "lastModified": 1784949315,
+        "narHash": "sha256-DFb7pfxvQIzfj/UiET+jNesON0nt3+5pk11URu+Nqrc=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "ddadbf248cacdd057658d30bd079e589e7c2b750",
+        "rev": "a3391389b07fc616f6cc301005013f64f9d4e7e3",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783864904,
-        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
+        "lastModified": 1784440659,
+        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
+        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784344906,
-        "narHash": "sha256-aEMNpfC0Tz46TfCXcxD+x4p7+sQO6+Dwacsif0L3hUc=",
+        "lastModified": 1784998108,
+        "narHash": "sha256-Bcplstv6cEphwzggdZ2LB3sZDimmF/QkaVkW9qk17no=",
         "owner": "4evy",
         "repo": "nixcord",
-        "rev": "c1285ad3cd7619bb58069b647086113f7e22597a",
+        "rev": "cca6d30eb701c1189f046f7d22f24ba85a6e07e3",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780811447,
-        "narHash": "sha256-H2UAcXvmdpgZi4trdX1hoJIteXdoqod5Vbs9oB+O4VY=",
+        "lastModified": 1784453950,
+        "narHash": "sha256-RbiUGTBwll3fhl8ODcztpN/SzCQ6LWw/TKwavfi4VYA=",
         "owner": "nix-community",
         "repo": "nixos-cli",
-        "rev": "fef2683f62b984a4c7b19eaf258f5dc387ec3447",
+        "rev": "62c0cac1cc537424ec09b3eee7474ade51099321",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784280462,
-        "narHash": "sha256-tdf956RzIg3clDWEZsQrngaEJVxpPNzUsGhVHgGKBj8=",
-        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "lastModified": 1784856561,
+        "narHash": "sha256-/HjbyQqfFs3cG7o/zJ25RPaLZqS9a88z6vOGhMoZwRs=",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.5449.293d6abedf04/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.5984.597283ad8aa0/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -730,11 +730,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-zupdTm41be2fY8cexroEOGjopl3F2Gqs3gk7ieqaM3s=",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "lastModified": 1784796856,
+        "narHash": "sha256-vwxWgF+Gj276WznzGb1LxGsK/39HaQwgQXiU3EkC844=",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1036777.61b7c44c4073/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1040357.e2587caef70c/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -751,11 +751,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784405431,
-        "narHash": "sha256-ZW+dSOHPW6is1twRV7syMrQIU6kq5cik/CkUdM511ZQ=",
+        "lastModified": 1784999727,
+        "narHash": "sha256-BFPW/2VW4SVUd42b348YPmOBXmxRmnTPyY9OuIXOz6Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5626dd82beb80ee178cd4729a016ca9063d86100",
+        "rev": "84ecee1374ff89394dc7b2094c2a5ae382cc1065",
         "type": "github"
       },
       "original": {
@@ -775,11 +775,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784320861,
-        "narHash": "sha256-sPUghbl8wMmESus7KvsmHIUEyD2mi13/xu7/u2H5SZU=",
+        "lastModified": 1784917177,
+        "narHash": "sha256-BunxD3nKN6oa4LXh9I3rAopolL0bloBtswKBXrm8hEE=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "43fdcbf2e00290479d3f9b97b7f61edd08c4e584",
+        "rev": "07d5eb208b8f16306b10342b634da7e07e926fa5",
         "type": "github"
       },
       "original": {

--- a/nix/hosts/mephistopheles/fonts.nix
+++ b/nix/hosts/mephistopheles/fonts.nix
@@ -20,17 +20,17 @@
       defaultFonts = {
         emoji = [ "Noto Color Emoji" ];
         monospace = [
-          "Inconsolata Go Nerd Font Mono"
+          "InconsolataGo Nerd Font Mono"
           "Noto Sans Mono"
           "Noto Sans Math"
         ];
         sansSerif = [
-          "Inconsolata Go Nerd Font"
+          "InconsolataGo Nerd Font"
           "Noto Sans"
           "Noto Sans Math"
         ];
         serif = [
-          "Inconsolata Go Nerd Font"
+          "InconsolataGo Nerd Font"
           "Noto Serif"
           "Noto Sans Math"
         ];

--- a/nix/users/ilkecan/appearence/fonts.nix
+++ b/nix/users/ilkecan/appearence/fonts.nix
@@ -27,17 +27,17 @@
   stylix.fonts = {
     serif = {
       package = pkgs.nerd-fonts.inconsolata-go;
-      name = "Inconsolata Go Nerd Font";
+      name = "InconsolataGo Nerd Font";
     };
 
     sansSerif = {
       package = pkgs.nerd-fonts.inconsolata-go;
-      name = "Inconsolata Go Nerd Font";
+      name = "InconsolataGo Nerd Font";
     };
 
     monospace = {
       package = pkgs.nerd-fonts.inconsolata-go;
-      name = "Inconsolata Go Nerd Font Mono";
+      name = "InconsolataGo Nerd Font Mono";
     };
 
     emoji = {

--- a/nix/users/ilkecan/command-line/shells/zsh/default.nix
+++ b/nix/users/ilkecan/command-line/shells/zsh/default.nix
@@ -54,6 +54,10 @@ in
         ## aliases
         ${concatLines (mapAttrsToList (n: v: "alias ${n}=${escapeShellArg v}") aliases)}
       '')
+
+      ''
+        eval "$(devenv hook zsh)"
+      ''
     ];
 
     completionInit = ''

--- a/nix/users/ilkecan/default.nix
+++ b/nix/users/ilkecan/default.nix
@@ -27,6 +27,7 @@ in
     pwvucontrol
     ruffle # https://github.com/ruffle-rs/ruffle
     telegram-desktop # https://github.com/NixOS/nixpkgs/issues/497549
+    diff-pdf # https://github.com/vslavik/diff-pdf
 
     ast-grep # https://github.com/ast-grep/ast-grep
     bottom

--- a/nix/users/ilkecan/gaming/default.nix
+++ b/nix/users/ilkecan/gaming/default.nix
@@ -14,9 +14,10 @@ in
 
   home.packages = with pkgs; [
     goverlay # github.com/benjamimgois/goverlay
-    hyperion-ng
-    itch
-    moonlight-qt
+    hyperion-ng # https://github.com/hyperion-project/hyperion.ng
+    itch # https://github.com/itchio/itch
+    moonlight-qt # https://github.com/moonlight-stream/moonlight-qt
+    nur.repos.ilkecan.pokeclicker-desktop # https://github.com/RedSparr0w/Pokeclicker-desktop
     protonplus # https://github.com/Vysp3r/ProtonPlus
   ];
 

--- a/nix/users/ilkecan/internet/instant-messaging/matrix.nix
+++ b/nix/users/ilkecan/internet/instant-messaging/matrix.nix
@@ -5,6 +5,7 @@
 
 {
   home.packages = with pkgs; [
-    fluffychat
+    fluffychat # https://github.com/krille-chan/fluffychat
+    matrix-commander-rs # https://github.com/8go/matrix-commander-rs
   ];
 }

--- a/nix/users/ilkecan/internet/web/browsers/firefox/profiles/ilkecan/search.nix
+++ b/nix/users/ilkecan/internet/web/browsers/firefox/profiles/ilkecan/search.nix
@@ -39,6 +39,7 @@ in
       "github"
       "youtube"
       "urban-dictionary"
+      "wayback-machine"
 
       "lens"
       "tineye"
@@ -332,6 +333,17 @@ in
           urls = [ { template = "https://www.urbandictionary.com/define.php?term={searchTerms}"; } ];
           iconMapObj."48" = "https://www.urbandictionary.com/favicon.ico";
           definedAliases = [ "@urban" ];
+        };
+
+        wayback-machine = {
+          name = "Wayback Machine";
+          urls = [ { template = "https://web.archive.org/web/{searchTerms}"; } ];
+          iconMapObj."32" = "https://web-static.archive.org/_static/images/archive.ico";
+          definedAliases = [
+            "@wayback-machine"
+            "@wayback"
+            "@wb"
+          ];
         };
 
         wikipedia2 = {

--- a/nix/users/ilkecan/internet/web/browsers/firefox/profiles/ilkecan/search.nix
+++ b/nix/users/ilkecan/internet/web/browsers/firefox/profiles/ilkecan/search.nix
@@ -40,6 +40,10 @@ in
       "youtube"
       "urban-dictionary"
 
+      "lens"
+      "tineye"
+      "yandex-reverse-image"
+
       "nixpkgs"
       "nix-packages"
       "nixos-options"
@@ -177,6 +181,17 @@ in
           ];
         };
 
+        lens = {
+          name = "Google Lens";
+          urls = [ { template = "https://lens.google.com/uploadbyurl?url={searchTerms}"; } ];
+          iconMapObj."32" = "https://www.google.com/favicon.ico";
+          definedAliases = [
+            "@google-lens"
+            "@glens"
+            "@lens"
+          ];
+        };
+
         nix-packages = {
           name = "Nix Packages";
           urls = [ { template = "https://search.nixos.org/packages?query={searchTerms}"; } ];
@@ -302,6 +317,16 @@ in
           ];
         };
 
+        tineye = {
+          name = "TinEye";
+          urls = [ { template = "https://tineye.com/search?url={searchTerms}"; } ];
+          iconMapObj."16" = "https://tineye.com/favicon.ico";
+          definedAliases = [
+            "@tineye"
+            "@te"
+          ];
+        };
+
         urban-dictionary = {
           name = "Urban Dictionary";
           urls = [ { template = "https://www.urbandictionary.com/define.php?term={searchTerms}"; } ];
@@ -317,6 +342,16 @@ in
             "@wikipedia"
             "@wiki"
             "@wk"
+          ];
+        };
+
+        yandex-reverse-image = {
+          name = "Yandex Reverse Image";
+          urls = [ { template = "https://yandex.com/images/search?rpt=imageview&url={searchTerms}"; } ];
+          iconMapObj."48" = "https://yandex.com/favicon.ico";
+          definedAliases = [
+            "@yandex-reverse-image"
+            "@yri"
           ];
         };
 

--- a/nix/users/ilkecan/internet/web/feed.nix
+++ b/nix/users/ilkecan/internet/web/feed.nix
@@ -5,6 +5,6 @@
 
 {
   home.packages = with pkgs; [
-    newsflash # https://gitlab.com/news-flash/news_flash_gtk
+    unstable.newsflash # https://gitlab.com/news-flash/news_flash_gtk
   ];
 }

--- a/nix/users/ilkecan/nix/default.nix
+++ b/nix/users/ilkecan/nix/default.nix
@@ -37,7 +37,6 @@ in
     nix-diff # https://github.com/Gabriella439/nix-diff
     nix-du # https://github.com/symphorien/nix-du
     nix-melt # https://github.com/nix-community/nix-melt
-    nix-olde # https://github.com/trofi/nix-olde
     nix-output-monitor # https://github.com/maralorn/nix-output-monitor
     nix-tree # https://github.com/utdemir/nix-tree
     nix-update # https://github.com/Mic92/nix-update/
@@ -47,6 +46,7 @@ in
     nixpkgs-review # https://github.com/Mic92/nixpkgs-review
     unstable.nix-eval-jobs # https://github.com/nix-community/nix-eval-jobs
     unstable.nix-fast-build # https://github.com/Mic92/nix-fast-build
+    unstable.nix-olde # https://github.com/trofi/nix-olde
   ];
 
   programs = {

--- a/nix/users/ilkecan/packaging.nix
+++ b/nix/users/ilkecan/packaging.nix
@@ -6,6 +6,7 @@
 {
   home.packages = with pkgs; [
     asar # https://github.com/electron/asar
+    cntr # https://github.com/Mic92/cntr, used by `pkgs.breakpointHook`
     dpkg # for `dpkg-deb`
     icoutils # for `icotool`
   ];

--- a/nix/users/ilkecan/utilities/zellij/layouts.nix
+++ b/nix/users/ilkecan/utilities/zellij/layouts.nix
@@ -49,6 +49,13 @@ let
       };
     };
 
+    processes = {
+      pane = {
+        _props.command = "devenv";
+        args = [ "up" ];
+      };
+    };
+
     shell = {
       pane._props.command = config.home.defaultShell.meta.mainProgram;
     };
@@ -85,6 +92,22 @@ let
         ];
       };
     };
+
+    processes = {
+      tab = {
+        _props = {
+          name = "processes";
+          hide_floating_panes = true;
+        };
+
+        _children = [
+          panes.processes
+          (panes.mkFloating panes.shell)
+          panes.bar
+        ];
+      };
+    };
+
   };
 in
 {

--- a/nix/users/ilkecan/utilities/zellij/layouts.nix
+++ b/nix/users/ilkecan/utilities/zellij/layouts.nix
@@ -24,6 +24,13 @@ let
       };
     };
 
+    devenv = {
+      pane = {
+        _props.command = "devenv";
+        args = [ "up" ];
+      };
+    };
+
     llmAgent = {
       pane = {
         _props.command = "codex";
@@ -49,19 +56,27 @@ let
       };
     };
 
-    processes = {
-      pane = {
-        _props.command = "devenv";
-        args = [ "up" ];
-      };
-    };
-
     shell = {
       pane._props.command = config.home.defaultShell.meta.mainProgram;
     };
   };
 
   tabs = {
+    devenv = {
+      tab = {
+        _props = {
+          name = "devenv";
+          hide_floating_panes = true;
+        };
+
+        _children = [
+          panes.devenv
+          (panes.mkFloating panes.shell)
+          panes.bar
+        ];
+      };
+    };
+
     llmAgent = {
       tab = {
         _props = {
@@ -92,22 +107,6 @@ let
         ];
       };
     };
-
-    processes = {
-      tab = {
-        _props = {
-          name = "processes";
-          hide_floating_panes = true;
-        };
-
-        _children = [
-          panes.processes
-          (panes.mkFloating panes.shell)
-          panes.bar
-        ];
-      };
-    };
-
   };
 in
 {

--- a/nix/users/ilkecan/utilities/zellij/layouts/code.nix
+++ b/nix/users/ilkecan/utilities/zellij/layouts/code.nix
@@ -6,7 +6,7 @@
 
 {
   layout._children = [
-    tabs.llmAgent
+    tabs.processes
     tabs.neovim
 
     {

--- a/nix/users/ilkecan/utilities/zellij/layouts/code.nix
+++ b/nix/users/ilkecan/utilities/zellij/layouts/code.nix
@@ -6,7 +6,7 @@
 
 {
   layout._children = [
-    tabs.processes
+    tabs.devenv
     tabs.neovim
 
     {

--- a/nix/users/ilkecan/wayland/niri/window-rules.nix
+++ b/nix/users/ilkecan/wayland/niri/window-rules.nix
@@ -27,6 +27,10 @@
       open-on-workspace = "nixpkgs";
     }
     {
+      matches = [ { app-id = "^camoufox$"; } ];
+      open-on-output = "eDP-1";
+    }
+    {
       matches = [ { app-id = "^chromium-browser$"; } ];
       open-maximized = true;
       open-on-workspace = "browser";

--- a/nix/users/ilkecan/wayland/niri/window-rules.nix
+++ b/nix/users/ilkecan/wayland/niri/window-rules.nix
@@ -94,6 +94,11 @@
       open-on-workspace = "password";
     }
     {
+      matches = [ { app-id = ''^org\.qutebrowser\.qutebrowser$''; } ];
+      open-maximized = true;
+      open-on-workspace = "browser";
+    }
+    {
       matches = [ { app-id = ''^org\.telegram\.desktop$''; } ];
       block-out-from = "screen-capture";
       open-maximized = true;

--- a/nix/users/ilkecan/xdg/mime-apps.nix
+++ b/nix/users/ilkecan/xdg/mime-apps.nix
@@ -8,13 +8,15 @@
   # https://wiki.archlinux.org/title/XDG_MIME_Applications
   xdg.mimeApps = {
     enable = true;
+
     defaultApplicationPackages = with pkgs; [
-      vlc
       config.programs.mpv.package
       config.programs.imv.package
       # config.programs.feh.package
       config.programs.firefox.package
       config.programs.zathura.package
+      neovide
+      vlc
     ];
   };
 }

--- a/nix/users/ilkecan/xdg/mime-apps.nix
+++ b/nix/users/ilkecan/xdg/mime-apps.nix
@@ -18,5 +18,11 @@
       neovide
       vlc
     ];
+
+    defaultApplications = {
+      "text/markdown" = [
+        "neovide.desktop"
+      ];
+    };
   };
 }


### PR DESCRIPTION
- ilkecan/nix-olde: use `unstable`
- ilkecan/firefox: add `lens`, `tineye`, `yandex-reverse-image` searches
- ilkecan/zsh: add devenv hook
- ilkecan/zellij: replace LLM agent tab with processes in `code` layout
- ilkecan/niri: add `camoufox` window rule
- ilkecan/zellij: rename `processes` to `devenv` in layouts
- ilkecan/newsflash: use `unstable`
- ilkecan/programs: add `diff-pdf`
- mephi,ilkecan: fix font family names
- ilkecan/xdg: set `neovide` as default application
- ilkecan/xdg: set `neovide` as a default app for `text/markdown`
- ilkecan/niri: add `qutebrowser` window rule
- ilkecan/packages: add `matrix-commander-rs`
- ilkecan/packages: add `cntr`
- ilkecan/firefox: add `wayback-machine` search
- flake: update inputs
- ilkecan/programs: add `nur.repos.ilkecan.pokeclicker-desktop`
