### PR TITLE
bulk: 2026-08-11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,13 @@ jobs:
     permissions:
       contents: read # required for `actions/checkout`
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: wimpysworld/nothing-but-nix@v10
         with:
           nix-permission-edict: true
 
-      - uses: nixbuild/nix-quick-install-action@v34
+      - uses: nixbuild/nix-quick-install-action@v35
         with:
           nix_conf: |
             experimental-features = ca-derivations flakes impure-derivations nix-command

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
         with:
           nix-permission-edict: true
 
-      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/install-nix-action@v31
         with:
-          nix_version: 2.35.1
-          nix_conf: |
+          install_url: https://releases.nixos.org/nix/nix-2.35.1/install
+          extra_nix_config: |
             experimental-features = ca-derivations flakes impure-derivations nix-command
             extra-substituters = https://ilkecan.cachix.org?priority=41 https://nix-community.cachix.org?priority=42
             extra-trusted-public-keys = ilkecan.cachix.org-1:hXb7Vo9EzaXiEb0elvG6Tt5TrP3zrcadyoX8c+lbeCY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
 
       - uses: nixbuild/nix-quick-install-action@v35
         with:
+          nix_version: 2.35.1
           nix_conf: |
             experimental-features = ca-derivations flakes impure-derivations nix-command
             extra-substituters = https://ilkecan.cachix.org?priority=41 https://nix-community.cachix.org?priority=42

--- a/flake.lock
+++ b/flake.lock
@@ -728,6 +728,29 @@
         "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
       }
     },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784686015,
+        "narHash": "sha256-HpbHqOrLbDS+ZTK2u9iojvWfMlWnuPzGb9XGcEipIxE=",
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "8d51e95247ca71680b72cdd308fdf1dbeb031313",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1785828668,
@@ -839,6 +862,7 @@
         "nixos-cli": "nixos-cli",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "nvf": "nvf",

--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785617619,
-        "narHash": "sha256-MDUHB9hKjP6nse+zTqgbcb1/pBgjV/FJ1j/4hkChu+M=",
+        "lastModified": 1786310616,
+        "narHash": "sha256-aQOU08ECTd0savQD80AIGG9sqQ41zWHcWZeuUzz39ts=",
         "owner": "AvengeMedia",
         "repo": "dankcalendar",
-        "rev": "01a431722fe2afbfc6e99698a7ba9894ca834a5e",
+        "rev": "a57a879061cd482c416d5ece44cb529249c37b06",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786275722,
-        "narHash": "sha256-N9k2QRu5tMqjxabaIkhrB7wT2z+fSai0UoUz10b9KFs=",
+        "lastModified": 1786525140,
+        "narHash": "sha256-NsnOvOPTemA3VOAyYXI0RE4wNPJmyU2BpY/KBwmwftw=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "88955f58b3405f7b1dc744943d10c0e81a7009dc",
+        "rev": "61607176682caa2cdea86c7f1f8d48743ec310d6",
         "type": "github"
       },
       "original": {
@@ -434,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786275593,
-        "narHash": "sha256-JcorQMqnmYSI0Kw53P/Gr0GUrHAqSBR1SvEiUPIF828=",
+        "lastModified": 1786568663,
+        "narHash": "sha256-R87WNxSHF77td52baayUyRq1K60oW+J8NBvKHBYshIQ=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "a3cf44d5a3082134ada0d95736f542954eecd3f7",
+        "rev": "bff0ebdf0bc651d0c93ed7d5404b2d6325adfd33",
         "type": "github"
       },
       "original": {
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786240022,
-        "narHash": "sha256-8tlAn+GMaMphBYEzVBqTf/ehnv9+TTt7GYf6ZfKZ5S8=",
+        "lastModified": 1786560897,
+        "narHash": "sha256-wO4spQEPVO7orFUEgAXVTJE/wgsNclORLjCQN4Q6ceA=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "557ca835f6c4890900b25852356702b5f745c972",
+        "rev": "11b2375eff5ba43f421380fff7ead2296c99b28b",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786240693,
-        "narHash": "sha256-nygXW2oqRUobkaUITUMxMD99f0Gag3zOL3PveV1fpmE=",
+        "lastModified": 1786327796,
+        "narHash": "sha256-MKutBNtJXWJQJw/HUjYOSHWYThmyKzF/VqwAAUvsing=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "6ca4f2bef08dc231d8dee17358a0965abdb0ccfb",
+        "rev": "60bc418493cd51959e707d5b83da8e9b4258aa25",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786251505,
-        "narHash": "sha256-LFU9VIQp9i9woVUyyuHNZbaPiw7sD//lsn4S0awg/Gw=",
+        "lastModified": 1786530600,
+        "narHash": "sha256-4bsIkFdLMj/IkYIC6D4MmMGz/oR0WAKkHW0Umm1NJ9M=",
         "owner": "4evy",
         "repo": "nixcord",
-        "rev": "a2c231759b0853d7b4adcef94860af472c5ce0fb",
+        "rev": "f4c14da614eb4e146cd8b65426038c75b06596f9",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786089803,
-        "narHash": "sha256-iDLHbagLeTbQwI79zkbPdsUbwPvsk6nCJNSep+l1BRk=",
-        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
+        "lastModified": 1786430034,
+        "narHash": "sha256-1MqAfG80fHLnWolvR3ULsMsXwMKFIJaWob8OI9yRcB0=",
+        "rev": "70cc4559b10a6062b05ff1af17e0add065ccaed9",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.7201.ee48b147c18c/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.7443.70cc4559b10a/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -738,11 +738,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784686015,
-        "narHash": "sha256-HpbHqOrLbDS+ZTK2u9iojvWfMlWnuPzGb9XGcEipIxE=",
+        "lastModified": 1786471740,
+        "narHash": "sha256-9PEUIbLorWC455Oa/4dxuLh+PFPfENBOgEN52gw+Onk=",
         "owner": "cachix",
         "repo": "nixpkgs-python",
-        "rev": "8d51e95247ca71680b72cdd308fdf1dbeb031313",
+        "rev": "4d2bd16c09baaa04f4045f16f6a5574654aaba16",
         "type": "github"
       },
       "original": {
@@ -753,11 +753,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-CgKDSHL6rqAAQkkvg1xaZDQXb77+4XW73iGcUMJ+2w0=",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "lastModified": 1786384358,
+        "narHash": "sha256-OETwiymkMwunF+pfL25DzLMF2/YpMcJUjVd9qZ0YdsM=",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1049422.f13ff45afd1b/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1051473.2fcb964de67f/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -774,11 +774,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786276606,
-        "narHash": "sha256-V4FKpdAZPM4SMK2YMRMItQrXcIZW/3gP00VGCFkuNwY=",
+        "lastModified": 1786568377,
+        "narHash": "sha256-FTuwkEYlJtcFiLTWH6qzLqWlKdXRUgQIwSSDv1nYVgk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af8e51e9a5ca7b9714bc7d0307877a6f768e310e",
+        "rev": "b6caf740b46b3b6d4581c5b00dd2ebf2a375b45a",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786375908,
+        "narHash": "sha256-G7qDAT98nywA4EFmJCwIRO5wKvDlBBN3BWpsOnjAto8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "d1337e05ba0a8e88a75d2c0e1595d82f3b3e2ac4",
         "type": "github"
       },
       "original": {
@@ -919,11 +919,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1786131255,
-        "narHash": "sha256-TktYK5NhNlUB/1r3CciMbza0mWwBR8o3nu9nAPFWpyo=",
+        "lastModified": 1786383226,
+        "narHash": "sha256-SM00z+A0/ruFPGCRdoxDnApVGa3A1iLlhRmMvnGH7tU=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "350298a8cfda10544952857f82323f7bf9c0e42d",
+        "rev": "a01dcef2f28b4106d6b3817ab89280194bf716d3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785635705,
-        "narHash": "sha256-b2bNAN2mBCaSfYvn/ILpf23TVnVIIyvhMMYCE3QJ13U=",
+        "lastModified": 1785837952,
+        "narHash": "sha256-qR1iA3vRQ7dlMOK5Eh3c3nZP8ivBTIoHJyAjoPJgiHo=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "bd0adca992b502178e70cc015f2a34f2b7031186",
+        "rev": "76b6fd4eff87231228c7ae12cf0d4ef16b94d559",
         "type": "github"
       },
       "original": {
@@ -434,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785669081,
-        "narHash": "sha256-yPFTUSVcP5j2fr3i9z8BUuOX/vLX18x1bGVrbdibHUM=",
+        "lastModified": 1785874803,
+        "narHash": "sha256-WtHe/wMn137NLUuZOI4M2po82S4DfBteNzNUT9a/xjI=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "90ab5cd4a6219ccbab83b4ede91b3fa63de3c6ee",
+        "rev": "04984e7c21be327f4853628e46c7c531d49014af",
         "type": "github"
       },
       "original": {
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785639802,
-        "narHash": "sha256-YBdUByl77pyZk6NorxgfZXtHH3lP/xdwYscm6sKTSCk=",
+        "lastModified": 1785721277,
+        "narHash": "sha256-ZIFiJkjvCqzjHtkPnf8Mxpa9gDWg1CJGGugoW1kpFtc=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "2dcca7126005deb548ed2eb13e6b95b575eda789",
+        "rev": "48495c7bfec5594d897b7a380edf75810cfa264d",
         "type": "github"
       },
       "original": {
@@ -502,11 +502,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785610189,
-        "narHash": "sha256-6m4cY11Fzv/GXrWBwC9RTrK7Kj5g2rmxrAy+cBIHnSY=",
+        "lastModified": 1785857305,
+        "narHash": "sha256-25q05zpF1sqOCxPPUG9DPPGd+EDW7SiAOWCzBWRS7r0=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "db5a178309551a16c0ca895ec55a2592c6daf963",
+        "rev": "9ee3e13b60643448228353097880521658b2fe0e",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785640717,
-        "narHash": "sha256-3wFAa6T5sNHLzGIAGuBUWaU/qB96E4BKi/zSfohQLV0=",
+        "lastModified": 1785812511,
+        "narHash": "sha256-Uy9HdSGApgNS+7JzGx4yM+CqUYNnyC6f09UpwgkeIRk=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "4d85e496f93260fc895775b1fef7534b4495dc4d",
+        "rev": "fbfc89e7670a207bef540a6248838855fe43dfe5",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785665023,
-        "narHash": "sha256-oIh4qaMSUaeyYHVZ8MyO6s6WTGKSUACVwDPT/4qEeAU=",
+        "lastModified": 1785866135,
+        "narHash": "sha256-ugvn1/SwNQDsYx8XM7FoAsPe9WL/ZMMjWgB/acoeeCs=",
         "owner": "4evy",
         "repo": "nixcord",
-        "rev": "87f4db7b3135b815a2969e99ef493fe3a663af7d",
+        "rev": "6385c7caabc51e9818e2ad32bc68178b4608ecb1",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785491804,
-        "narHash": "sha256-GGQER+O/plhJCG35JVsKYVwI8qtOKR7UB4E3e8DBKmQ=",
-        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
+        "lastModified": 1785734586,
+        "narHash": "sha256-rBYNiK4XmVxmJaK40DRnmoPUpCeRXJ4DJdQ/DW2LQRU=",
+        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.6603.5b4f72e1705a/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.6815.531670d871c0/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -730,11 +730,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785571196,
-        "narHash": "sha256-xwSqxTsama0YTtS78+4YyCm6jJg09v78QWfP1cAyoVA=",
-        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "lastModified": 1785828668,
+        "narHash": "sha256-VFlH/0nM6kkWQox9IaTqx2eCT3pmkr8bB7iVZ1bkaLs=",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1045728.148bab9c1c3c/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1047536.e72e4f299401/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -751,11 +751,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785678737,
-        "narHash": "sha256-xEBHDBp8CBJEhZf5liGoUJWDU5x1gxxWAeWDDe/G7JA=",
+        "lastModified": 1785875078,
+        "narHash": "sha256-sAcQxm+TIJH9BESN3vHduQR9s3EFVwr80hWb80o0Kjg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5281c595ab3c6c5f4bfb9c3f85e0729de7cdf136",
+        "rev": "f296b2b80ead353382b814af689789d838331d06",
         "type": "github"
       },
       "original": {
@@ -895,11 +895,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1785677223,
-        "narHash": "sha256-3b7nQjZtdjawE+9Hreelj21B9Ef0XIoWLOsoPfv8Umk=",
+        "lastModified": 1785795542,
+        "narHash": "sha256-f8itgyKF7J1i0EYhKf/eSrNfnqUR5OqR05Da3zP3UDc=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "2cb783b643c6655a01f684f272448690c9a1f529",
+        "rev": "bd34c34aecf7e9ca4f4c214ef69192c87588c55f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785837952,
-        "narHash": "sha256-qR1iA3vRQ7dlMOK5Eh3c3nZP8ivBTIoHJyAjoPJgiHo=",
+        "lastModified": 1786275722,
+        "narHash": "sha256-N9k2QRu5tMqjxabaIkhrB7wT2z+fSai0UoUz10b9KFs=",
         "owner": "AvengeMedia",
         "repo": "dms-plugin-registry",
-        "rev": "76b6fd4eff87231228c7ae12cf0d4ef16b94d559",
+        "rev": "88955f58b3405f7b1dc744943d10c0e81a7009dc",
         "type": "github"
       },
       "original": {
@@ -231,11 +231,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1779670703,
-        "narHash": "sha256-UdfMivNMwCCqQsYDg5pSz8X2IOaOrIZLIIy+Bg3CO2o=",
+        "lastModified": 1783570805,
+        "narHash": "sha256-ptl5aRlCv9/uRSv2u8Hq8UFVFeZ6Q/bT049bpqNgc3w=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "942159e73e40bf785816f7f1f5feed9ef3d7c8f9",
+        "rev": "5602ed62d638142c1ab31dccd01dfbfb28841225",
         "type": "github"
       },
       "original": {
@@ -434,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785874803,
-        "narHash": "sha256-WtHe/wMn137NLUuZOI4M2po82S4DfBteNzNUT9a/xjI=",
+        "lastModified": 1786275593,
+        "narHash": "sha256-JcorQMqnmYSI0Kw53P/Gr0GUrHAqSBR1SvEiUPIF828=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "04984e7c21be327f4853628e46c7c531d49014af",
+        "rev": "a3cf44d5a3082134ada0d95736f542954eecd3f7",
         "type": "github"
       },
       "original": {
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785721277,
-        "narHash": "sha256-ZIFiJkjvCqzjHtkPnf8Mxpa9gDWg1CJGGugoW1kpFtc=",
+        "lastModified": 1786240022,
+        "narHash": "sha256-8tlAn+GMaMphBYEzVBqTf/ehnv9+TTt7GYf6ZfKZ5S8=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "48495c7bfec5594d897b7a380edf75810cfa264d",
+        "rev": "557ca835f6c4890900b25852356702b5f745c972",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785812511,
-        "narHash": "sha256-Uy9HdSGApgNS+7JzGx4yM+CqUYNnyC6f09UpwgkeIRk=",
+        "lastModified": 1786240693,
+        "narHash": "sha256-nygXW2oqRUobkaUITUMxMD99f0Gag3zOL3PveV1fpmE=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "fbfc89e7670a207bef540a6248838855fe43dfe5",
+        "rev": "6ca4f2bef08dc231d8dee17358a0965abdb0ccfb",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785650611,
-        "narHash": "sha256-q4kR7g+pCcz6NASvoVPYu+CWWUurX03wogtBqGmR4h0=",
+        "lastModified": 1786249295,
+        "narHash": "sha256-Y2mSr+HLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "dbc756c9d7287de19b3e0e38c928c47510d42c3e",
+        "rev": "14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785866135,
-        "narHash": "sha256-ugvn1/SwNQDsYx8XM7FoAsPe9WL/ZMMjWgB/acoeeCs=",
+        "lastModified": 1786251505,
+        "narHash": "sha256-LFU9VIQp9i9woVUyyuHNZbaPiw7sD//lsn4S0awg/Gw=",
         "owner": "4evy",
         "repo": "nixcord",
-        "rev": "6385c7caabc51e9818e2ad32bc68178b4608ecb1",
+        "rev": "a2c231759b0853d7b4adcef94860af472c5ce0fb",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785734586,
-        "narHash": "sha256-rBYNiK4XmVxmJaK40DRnmoPUpCeRXJ4DJdQ/DW2LQRU=",
-        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
+        "lastModified": 1786089803,
+        "narHash": "sha256-iDLHbagLeTbQwI79zkbPdsUbwPvsk6nCJNSep+l1BRk=",
+        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.6815.531670d871c0/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.7201.ee48b147c18c/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -753,11 +753,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-VFlH/0nM6kkWQox9IaTqx2eCT3pmkr8bB7iVZ1bkaLs=",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "lastModified": 1786106723,
+        "narHash": "sha256-CgKDSHL6rqAAQkkvg1xaZDQXb77+4XW73iGcUMJ+2w0=",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1047536.e72e4f299401/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1049422.f13ff45afd1b/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -774,11 +774,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785875078,
-        "narHash": "sha256-sAcQxm+TIJH9BESN3vHduQR9s3EFVwr80hWb80o0Kjg=",
+        "lastModified": 1786276606,
+        "narHash": "sha256-V4FKpdAZPM4SMK2YMRMItQrXcIZW/3gP00VGCFkuNwY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f296b2b80ead353382b814af689789d838331d06",
+        "rev": "af8e51e9a5ca7b9714bc7d0307877a6f768e310e",
         "type": "github"
       },
       "original": {
@@ -919,11 +919,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1785795542,
-        "narHash": "sha256-f8itgyKF7J1i0EYhKf/eSrNfnqUR5OqR05Da3zP3UDc=",
+        "lastModified": 1786131255,
+        "narHash": "sha256-TktYK5NhNlUB/1r3CciMbza0mWwBR8o3nu9nAPFWpyo=",
         "owner": "nix-community",
         "repo": "stylix",
-        "rev": "bd34c34aecf7e9ca4f4c214ef69192c87588c55f",
+        "rev": "350298a8cfda10544952857f82323f7bf9c0e42d",
         "type": "github"
       },
       "original": {
@@ -967,11 +967,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1777806186,
-        "narHash": "sha256-PDF0/wObw4nIsSBeXVYLsloXOiphXCgIdsrNcVXguKs=",
+        "lastModified": 1785153830,
+        "narHash": "sha256-fNdfCTeCXU3tZG3TMincd+u68qBHQgCr2Ljr/M1mWP0=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "0c94645546f4f3ddac77a1a5fce54eb95bf50795",
+        "rev": "9bd28ed313560db3c5b605c63bc4e309e78e3fc8",
         "type": "github"
       },
       "original": {
@@ -983,11 +983,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1778379944,
-        "narHash": "sha256-wPDFzMGSlARlw0Sfsn48Q2+jPSfk6N0Ng6BC/d+7Q24=",
+        "lastModified": 1785031658,
+        "narHash": "sha256-mZp9O2LjzdMzlqQF3l3fjqsuPBzXy+1qTfBEUGjTlpk=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "fe0203a198690e71a5ff11e08812a4673de3678d",
+        "rev": "5d2c67f61ea7af36f16865ab6d541cdba41dc257",
         "type": "github"
       },
       "original": {
@@ -999,11 +999,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1778378178,
-        "narHash": "sha256-OXPXRIQgGwV77HjYRryOHguh4ALX96jkg+tseLkGgHA=",
+        "lastModified": 1785030526,
+        "narHash": "sha256-klZf8UviewRkxuu74Bhbq6tqy7oxebQC7UVRWbbtQxU=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "9cd816033ff969415b190722cddf134e78a5665f",
+        "rev": "16f5a8adf4a6b1310d0a61ab172de963e8f76a02",
         "type": "github"
       },
       "original": {
@@ -1019,11 +1019,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785360170,
-        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,13 @@
     import-tree = {
       url = "github:vic/import-tree";
     };
+    nixpkgs-python = {
+      url = "github:cachix/nixpkgs-python";
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
     systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";

--- a/nix/flake/home-configurations.nix
+++ b/nix/flake/home-configurations.nix
@@ -47,6 +47,7 @@ let
           extraSpecialArgs = {
             inherit
               hostConfig
+              inputs
               inputs'
               lib'
               self'

--- a/nix/flake/nixos-configurations.nix
+++ b/nix/flake/nixos-configurations.nix
@@ -39,6 +39,7 @@ let
 
           specialArgs = {
             inherit
+              inputs
               inputs'
               lib
               lib'

--- a/nix/hosts/mephistopheles/nix/default.nix
+++ b/nix/hosts/mephistopheles/nix/default.nix
@@ -9,10 +9,7 @@
 
 let
   inherit (lib)
-    filterAttrs
-    foldl'
     importJSON
-    isString
     mapAttrs
     mapAttrsToList
     toJSON
@@ -20,22 +17,16 @@ let
 
   inherit (lib._.ilkecan)
     importsFromDirectory
+    resolveFlakeLockNodeName
     ;
 
   lock = importJSON "${inputs.self}/flake.lock";
 
-  resolveNodeName =
-    inputSpec:
-    if isString inputSpec then
-      inputSpec
-    else
-      foldl' (
-        nodeName: inputName: resolveNodeName lock.nodes.${nodeName}.inputs.${inputName}
-      ) lock.root inputSpec;
+  resolveNodeName = resolveFlakeLockNodeName lock;
 
-  pins = mapAttrs (_name: inputSpec: lock.nodes.${resolveNodeName inputSpec}.locked) (
-    filterAttrs (name: _: name != "self") lock.nodes.${lock.root}.inputs
-  );
+  pins = mapAttrs (
+    _: inputSpec: lock.nodes.${resolveNodeName inputSpec}.locked
+  ) lock.nodes.${lock.root}.inputs;
 
   flakeRegistry = pkgs.writeText "flake-registry.json" (toJSON {
     version = 2;

--- a/nix/hosts/mephistopheles/nix/default.nix
+++ b/nix/hosts/mephistopheles/nix/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  inputs,
   lib,
   pkgs,
   userConfig,
@@ -7,9 +8,45 @@
 }:
 
 let
+  inherit (lib)
+    filterAttrs
+    foldl'
+    importJSON
+    isString
+    mapAttrs
+    mapAttrsToList
+    toJSON
+    ;
+
   inherit (lib._.ilkecan)
     importsFromDirectory
     ;
+
+  lock = importJSON "${inputs.self}/flake.lock";
+
+  resolveNodeName =
+    inputSpec:
+    if isString inputSpec then
+      inputSpec
+    else
+      foldl' (
+        nodeName: inputName: resolveNodeName lock.nodes.${nodeName}.inputs.${inputName}
+      ) lock.root inputSpec;
+
+  pins = mapAttrs (_name: inputSpec: lock.nodes.${resolveNodeName inputSpec}.locked) (
+    filterAttrs (name: _: name != "self") lock.nodes.${lock.root}.inputs
+  );
+
+  flakeRegistry = pkgs.writeText "flake-registry.json" (toJSON {
+    version = 2;
+    flakes = mapAttrsToList (id: to: {
+      from = {
+        type = "indirect";
+        inherit id;
+      };
+      inherit to;
+    }) pins;
+  });
 in
 {
   imports = importsFromDirectory ./.;
@@ -29,6 +66,9 @@ in
         "impure-derivations"
         "nix-command"
       ];
+
+      flake-registry = flakeRegistry;
+
       trusted-users = [ userConfig.home.username ];
 
       auto-optimise-store = true;

--- a/nix/inputs.nix
+++ b/nix/inputs.nix
@@ -10,10 +10,8 @@ let
     attrValues
     elem
     filterAttrs
-    foldl'
     importJSON
     intersectAttrs
-    isString
     mapAttrs
     mapAttrs'
     nameValuePair
@@ -24,6 +22,7 @@ let
     importTree
     isFlake
     isPatchedFlakeInput
+    resolveFlakeLockNodeName
     ;
 
   # NOTE: unfortunately there is no way to avoid hard-coded `system` yet
@@ -105,18 +104,13 @@ let
     normalizeNameFn = removeSuffix ".nix";
   });
 
+  lockFile = importJSON ../flake.lock;
+  inherit (lockFile) nodes root;
+
   # Resolve a lock node reference to its canonical node name.
   # String refs are already node names; array refs are follow-paths from root
   # (e.g. ["nixpkgs"] resolves root -> nixpkgs, ["bar","foo"] resolves root -> bar -> foo).
-  resolveNodeName =
-    inputSpec:
-    if isString inputSpec then
-      inputSpec
-    else
-      foldl' (nodeName: inputName: resolveNodeName nodes.${nodeName}.inputs.${inputName}) root inputSpec;
-
-  lockFile = importJSON ../flake.lock;
-  inherit (lockFile) nodes root;
+  resolveNodeName = resolveFlakeLockNodeName lockFile;
 
   rootInputs = nodes.${root}.inputs;
   resolveTopLevelNodeName = name: resolveNodeName rootInputs.${name};

--- a/nix/modules/home-manager/firefox-betterfox-default-version.nix
+++ b/nix/modules/home-manager/firefox-betterfox-default-version.nix
@@ -1,6 +1,6 @@
 {
   config,
-  inputs',
+  inputs,
   lib,
   ...
 }:
@@ -17,7 +17,7 @@ let
 
   cfg = config.programs.firefox;
   firefoxVersion = versions.majorMinor cfg.package.version;
-  supportedVersions = attrNames (import "${inputs'.betterfox-nix}/data/firefox");
+  supportedVersions = attrNames (import "${inputs.betterfox-nix}/data/firefox");
   version =
     if elem firefoxVersion supportedVersions then
       firefoxVersion

--- a/nix/modules/home-manager/xdg-bin-file.nix
+++ b/nix/modules/home-manager/xdg-bin-file.nix
@@ -1,6 +1,6 @@
 {
   config,
-  inputs',
+  inputs,
   lib,
   pkgs,
   ...
@@ -21,7 +21,7 @@ let
     ;
 
   fileType =
-    (import "${inputs'.home-manager}/modules/lib/file-type.nix" {
+    (import "${inputs.home-manager}/modules/lib/file-type.nix" {
       inherit homeDirectory lib pkgs;
     }).fileType;
 in

--- a/nix/users/ilkecan/internet/instant-messaging/discord.nix
+++ b/nix/users/ilkecan/internet/instant-messaging/discord.nix
@@ -5,7 +5,7 @@
 {
   programs.nixcord = {
     enable = true;
-    discord.silenceNoModClientWarning = true;
+    discord.enable = false;
     dorion = {
       enable = true;
       cacheCss = true;

--- a/nix/users/ilkecan/internet/web/browsers/firefox/profiles/ilkecan/extensions/skip-redirect.nix
+++ b/nix/users/ilkecan/internet/web/browsers/firefox/profiles/ilkecan/extensions/skip-redirect.nix
@@ -9,7 +9,7 @@
     packages = [ pkgs.nur.repos.rycee.firefox-addons.skip-redirect ];
     settings."skipredirect@sblask" = {
       permissions = [
-        "<all_urls>"
+        "alarms"
         "clipboardWrite"
         "contextMenus"
         "notifications"

--- a/nix/users/ilkecan/nix/default.nix
+++ b/nix/users/ilkecan/nix/default.nix
@@ -1,6 +1,6 @@
 {
   config,
-  inputs',
+  inputs,
   lib,
   pkgs,
   ...
@@ -19,7 +19,7 @@ in
   imports = importsFromDirectory ./.;
 
   nix.channels = {
-    inherit (inputs')
+    inherit (inputs)
       nixpkgs
       nixpkgs-unstable
       ;

--- a/nix/users/ilkecan/nix/optnix.nix
+++ b/nix/users/ilkecan/nix/optnix.nix
@@ -1,5 +1,5 @@
 {
-  inputs',
+  inputs,
   lib,
   pkgs,
   self',
@@ -14,7 +14,7 @@ let
     nameValuePair
     ;
 
-  inherit (inputs'.optnix.mkLib pkgs) mkOptionsList;
+  inherit (inputs.optnix.mkLib pkgs) mkOptionsList;
 
   mkFlakePartsScope = flake: {
     description = "flake-parts top level configuration";

--- a/nix/users/ilkecan/security/secret-service.nix
+++ b/nix/users/ilkecan/security/secret-service.nix
@@ -6,6 +6,7 @@
 {
   home.packages = with pkgs; [
     gcr
+    seahorse
   ];
 
   services = {

--- a/nix/users/ilkecan/security/secret-service.nix
+++ b/nix/users/ilkecan/security/secret-service.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  home.packages = with pkgs; [
+    gcr
+  ];
+
+  services = {
+    gnome-keyring.enable = true;
+  };
+}

--- a/nix/users/ilkecan/text-editors/neovim/lua.nix
+++ b/nix/users/ilkecan/text-editors/neovim/lua.nix
@@ -1,10 +1,10 @@
 {
-  inputs',
+  inputs,
   ...
 }:
 
 let
-  inherit (inputs'.nvf.lib.nvim)
+  inherit (inputs.nvf.lib.nvim)
     dag
     ;
 in

--- a/nix/users/ilkecan/utilities/zellij/plugins/zellij-autolock.nix
+++ b/nix/users/ilkecan/utilities/zellij/plugins/zellij-autolock.nix
@@ -8,7 +8,7 @@
   # https://github.com/fresh2dev/zellij-autolock#example-configkdl
   programs.zellij.settings = {
     plugins.autolock = {
-      _props.location = "file:${pkgs.nur.repos.ilkecan.zellij-autolock}/share/zellij/plugins/zellij-autolock.wasm";
+      _props.location = "file:${pkgs.unstable.zellijPlugins.autolock}";
 
       is_enabled = false;
       triggers = "nvim";

--- a/nix/users/ilkecan/wayland/default.nix
+++ b/nix/users/ilkecan/wayland/default.nix
@@ -67,8 +67,6 @@ in
   };
 
   services = {
-    gnome-keyring.enable = true;
-
     udiskie = {
       enable = true;
       automount = true;

--- a/nix/users/ilkecan/xdg/mime-apps.nix
+++ b/nix/users/ilkecan/xdg/mime-apps.nix
@@ -23,6 +23,9 @@
       "text/markdown" = [
         "neovide.desktop"
       ];
+      "inode/directory" = [
+        "org.gnome.Nautilus.desktop"
+      ];
     };
   };
 }


### PR DESCRIPTION
- ilkecan/programs: add `gcr`
- ilkecan/nixcord: explicitly disable discord
- ilkecan/programs: add `seahorse`
- flake: update inputs
- ilkecan/xdg: set `nautilus` as a default app for `inode/directory`
- flake: expose `inputs` to {home,nixos}Configurations
- mephi: set flake inputs as the flake registry
- flake: add `nixpkgs-python` for flake-registry
- flake: update inputs
